### PR TITLE
Surface fatal rollout generation failures

### DIFF
--- a/training/open-instruct/CHANGELOG.md
+++ b/training/open-instruct/CHANGELOG.md
@@ -22,6 +22,7 @@ All notable changes to this project will be documented in this file.
 - Add deprecation warning to `finetune.py` pointing users to the OLMo-core SFT implementation (https://github.com/allenai/open-instruct/pull/1574).
 
 ### Fixed
+- Surface fatal background rollout failures through the inference result queue so Sandfleet configuration errors wake data preparation and terminate training with their original message instead of wedging the trainer (https://github.com/hamishivi/tmax/pull/7).
 - Update ZeRO-3 reference policies through matching local shards instead of gathering parameters from two DeepSpeed engines in one collective, preventing hangs with sequence parallelism.
 - Fix `DataPreparationActor` hanging on shutdown by killing the actor with `ray.kill()` during cleanup (https://github.com/allenai/open-instruct/pull/1611).
 - Fix empty optimizer group error with torch 2.10 and DeepSpeed in `finetune.py`, `dpo_tune_cache.py`, and `utils.py`. (https://github.com/allenai/open-instruct/pull/1598)

--- a/training/open-instruct/open_instruct/data_loader.py
+++ b/training/open-instruct/open_instruct/data_loader.py
@@ -23,6 +23,7 @@ from pathlib import Path
 from queue import Empty
 from typing import Any, Literal, cast
 
+import docker as docker_sdk
 import numpy as np
 import ray
 import torch
@@ -125,8 +126,6 @@ class ImagePrewarmActor:
             return dict(self._stats) | {"seen": len(self._seen), "inflight": len(self._inflight)}
 
     def _pull_image(self, image: str) -> None:
-        import docker as docker_sdk
-
         client = docker_sdk.from_env(timeout=300)
         try:
             client.images.get(image)
@@ -1100,6 +1099,11 @@ def accumulate_inference_batches(
 
         if isinstance(result, data_types.ShutdownSentinel):
             return result, None, None, None
+        if isinstance(result, data_types.FatalGenerationError):
+            raise RuntimeError(
+                f"Fatal generation failure for {result.request_id}: "
+                f"{result.error_type}: {result.message}\n{result.traceback}"
+            )
 
         if (
             max_result_age_steps is not None
@@ -1807,17 +1811,12 @@ class DataPreparationActor:
             #    tool-using rollouts.
             num_before_filter = len(result.finish_reasons)
             response_length_cap = self.config.response_length
-
-            def _is_truncated(i: int) -> bool:
-                return result.finish_reasons[i] != "stop" or len(result.responses[i]) >= response_length_cap
-
-            def _is_non_submitting(i: int) -> bool:
-                states = result.request_info.rollout_states
-                if i >= len(states):
-                    return False
-                return not states[i].get("done", True)
-
-            truncated_idxes = [i for i in range(num_before_filter) if _is_truncated(i)]
+            rollout_states = result.request_info.rollout_states
+            truncated_idxes = [
+                i
+                for i in range(num_before_filter)
+                if result.finish_reasons[i] != "stop" or len(result.responses[i]) >= response_length_cap
+            ]
             num_truncated_completion = len(truncated_idxes)
             truncated_completion_correct_count = (
                 int(sum(1 for i in truncated_idxes if raw_scores[i] > 0)) if num_truncated_completion else 0
@@ -1826,28 +1825,29 @@ class DataPreparationActor:
                 [len(result.responses[i]) for i in truncated_idxes], dtype=np.int64
             )
 
-            non_submitting_idxes = [i for i in range(num_before_filter) if _is_non_submitting(i)]
+            non_submitting_idxes = [
+                i
+                for i in range(min(num_before_filter, len(rollout_states)))
+                if not rollout_states[i].get("done", True)
+            ]
             num_non_submitting_completion = len(non_submitting_idxes)
             num_unmasked_non_submitting_completion = 0
+            non_submitting_idxes_set = set(non_submitting_idxes)
 
             do_mask_filter = self.config.mask_truncated_completions or self.config.mask_non_submitting_completions
             if do_mask_filter:
-                truncated_drop_idxes = {
-                    i for i in range(num_before_filter) if self.config.mask_truncated_completions and _is_truncated(i)
-                }
-                non_submitting_drop_idxes = [
-                    i
-                    for i in range(num_before_filter)
+                truncated_drop_idxes = set(truncated_idxes) if self.config.mask_truncated_completions else set()
+                non_submitting_drop_idxes = (
+                    [i for i in non_submitting_idxes if i not in truncated_drop_idxes]
                     if self.config.mask_non_submitting_completions
-                    and _is_non_submitting(i)
-                    and i not in truncated_drop_idxes
-                ]
+                    else []
+                )
                 unmasked_non_submitting_idxes: set[int] = set()
                 if self.config.mask_non_submitting_completions_percent > 0.0:
                     submitting_keep_count = sum(
                         1
                         for i in range(num_before_filter)
-                        if i not in truncated_drop_idxes and not _is_non_submitting(i)
+                        if i not in truncated_drop_idxes and i not in non_submitting_idxes_set
                     )
                     unmasked_non_submitting_idxes = _sample_non_submitting_unmask_idxes(
                         submitting_count=submitting_keep_count,

--- a/training/open-instruct/open_instruct/data_types.py
+++ b/training/open-instruct/open_instruct/data_types.py
@@ -9,6 +9,16 @@ class ShutdownSentinel:
     """Sentinel value to signal thread shutdown via queue."""
 
 
+@dataclass(frozen=True)
+class FatalGenerationError:
+    """Unrecoverable background generation failure sent to the trainer."""
+
+    request_id: str
+    error_type: str
+    message: str
+    traceback: str
+
+
 @dataclass
 class TokenStatistics:
     """Container for token statistics from inference."""

--- a/training/open-instruct/open_instruct/test_grpo_fast.py
+++ b/training/open-instruct/open_instruct/test_grpo_fast.py
@@ -18,7 +18,14 @@ from transformers import AutoTokenizer
 
 from open_instruct import data_loader as data_loader_lib
 from open_instruct import rl_utils, utils
-from open_instruct.data_types import EnvConfig, GenerationResult, PromptRequest, RequestInfo, TokenStatistics
+from open_instruct.data_types import (
+    EnvConfig,
+    FatalGenerationError,
+    GenerationResult,
+    PromptRequest,
+    RequestInfo,
+    TokenStatistics,
+)
 from open_instruct.dataset_transformation import (
     GROUND_TRUTHS_KEY,
     INPUT_IDS_PROMPT_KEY,
@@ -997,6 +1004,30 @@ class TestStreamingAccumulation(TestGrpoFastBase):
 
 class TestAccumulateInferenceBatches(TestGrpoFastBase):
     """Test accumulate_inference_batches function."""
+
+    def test_fatal_generation_error_wakes_batch_consumer(self):
+        inference_results_Q = ray_queue.Queue(maxsize=1)
+        self._ray_queues.append(inference_results_Q)
+        inference_results_Q.put(
+            FatalGenerationError(
+                request_id="train_1",
+                error_type="ValueError",
+                message="Declarative resource requests are disabled; start the controller with --enable-dynamic-resources",
+                traceback="remote traceback",
+            )
+        )
+
+        with self.assertRaisesRegex(RuntimeError, "--enable-dynamic-resources"):
+            data_loader_lib.accumulate_inference_batches(
+                inference_results_Q,
+                Mock(n=1),
+                num_prompts=1,
+                model_dims=Mock(),
+                tokenizer=Mock(),
+                dataset=Mock(),
+                base_env_config=EnvConfig(),
+                timeout=1,
+            )
 
     def test_all_prompts_filtered_returns_none(self):
         """Test that accumulate_inference_batches returns None when all prompts are filtered."""

--- a/training/open-instruct/open_instruct/test_vllm_utils.py
+++ b/training/open-instruct/open_instruct/test_vllm_utils.py
@@ -1,5 +1,9 @@
 import logging
+import queue
+import threading
 import unittest
+from concurrent import futures
+from types import SimpleNamespace
 from unittest import mock
 from unittest.mock import MagicMock
 
@@ -7,7 +11,7 @@ import vllm
 from parameterized import parameterized
 
 from open_instruct import vllm_utils
-from open_instruct.data_types import PromptRequest
+from open_instruct.data_types import FatalGenerationError, PromptRequest
 from open_instruct.utils import ModelDims
 
 
@@ -31,6 +35,31 @@ class TestTruncateEnvOutputTokens(unittest.TestCase):
         )
         self.assertEqual(result, expected_tokens)
         self.assertEqual(excess, expected_excess)
+
+
+class TestFatalGenerationErrors(unittest.TestCase):
+    def test_background_failure_is_reported_once(self):
+        result_queue = queue.Queue()
+        actor = SimpleNamespace(
+            _request_failure_lock=threading.Lock(),
+            _reported_request_failures=set(),
+            results_queue=result_queue,
+            eval_results_queue=queue.Queue(),
+        )
+        first = futures.Future()
+        first.set_exception(ValueError("declarative resources are disabled"))
+        duplicate = futures.Future()
+        duplicate.set_exception(ValueError("same request"))
+
+        vllm_utils._report_request_failure(actor, "train_1", False, first)
+        vllm_utils._report_request_failure(actor, "train_1", False, duplicate)
+
+        failure = result_queue.get_nowait()
+        self.assertIsInstance(failure, FatalGenerationError)
+        self.assertEqual(failure.request_id, "train_1")
+        self.assertEqual(failure.error_type, "ValueError")
+        self.assertIn("declarative resources are disabled", failure.message)
+        self.assertTrue(result_queue.empty())
 
 
 class TestVllmUtils3(unittest.TestCase):

--- a/training/open-instruct/open_instruct/vllm_utils.py
+++ b/training/open-instruct/open_instruct/vllm_utils.py
@@ -57,6 +57,7 @@ from open_instruct import logger_utils, utils
 from open_instruct.data_types import (
     EnvConfig,
     EnvConfigEntry,
+    FatalGenerationError,
     GenerationResult,
     PromptRequest,
     RequestInfo,
@@ -69,13 +70,7 @@ from open_instruct.environments.tools.parsers import ToolParser, create_tool_par
 from open_instruct.ground_truth_utils import RewardConfig
 
 logger = logger_utils.setup_logger(__name__)
-SANDBOX_TIMING_LOGS = os.getenv("SWERL_SANDBOX_TIMING_LOGS", "").strip().lower() not in {
-    "",
-    "0",
-    "false",
-    "no",
-    "off",
-}
+SANDBOX_TIMING_LOGS = os.getenv("SWERL_SANDBOX_TIMING_LOGS", "").strip().lower() not in {"", "0", "false", "no", "off"}
 SANDBOX_TIMING_LOG_THRESHOLD_S = float(os.getenv("SWERL_SANDBOX_TIMING_LOG_THRESHOLD_S", "1.0"))
 RESET_FAILURE_ZERO_REWARD = os.getenv("SWERL_RESET_FAILURE_ZERO_REWARD", "").strip().lower() not in {
     "",
@@ -147,10 +142,7 @@ def patch_vllm_qwen3_5_lm_head_fp32() -> None:
     # default. This mirrors vLLM's MiniMax fix: do the final projection in fp32
     # to avoid bf16 rounding in logits/logprobs.
     patched_classes = []
-    for module_name in (
-        "vllm.model_executor.models.qwen3_5",
-        "vllm.model_executor.models.qwen3_5_mtp",
-    ):
+    for module_name in ("vllm.model_executor.models.qwen3_5", "vllm.model_executor.models.qwen3_5_mtp"):
         try:
             module = __import__(module_name, fromlist=[""])
         except ImportError:
@@ -534,9 +526,37 @@ def add_request(actor: "LLMRayActor", request: PromptRequest) -> None:
         seed = request.generation_config.seed + j if request.generation_config.seed is not None else None
         sub_sampling_params = dataclasses.replace(sampling_params, seed=seed)
         sub_request_id = f"{request_id}_{j}"
-        actor.active_tasks[sub_request_id] = asyncio.run_coroutine_threadsafe(
+        task = asyncio.run_coroutine_threadsafe(
             process_request(actor, sub_request_id, sub_sampling_params), actor.loop
         )
+        actor.active_tasks[sub_request_id] = task
+        task.add_done_callback(
+            lambda completed, request_id=request_id, is_eval=request.is_eval: _report_request_failure(
+                actor, request_id, is_eval, completed
+            )
+        )
+
+
+def _report_request_failure(actor: "LLMRayActor", request_id: str, is_eval: bool, task: futures.Future) -> None:
+    """Wake the result consumer immediately when a background request fails."""
+    if task.cancelled():
+        return
+    error = task.exception()
+    if error is None:
+        return
+    with actor._request_failure_lock:
+        if request_id in actor._reported_request_failures:
+            return
+        actor._reported_request_failures.add(request_id)
+    failure = FatalGenerationError(
+        request_id=request_id,
+        error_type=type(error).__name__,
+        message=str(error),
+        traceback="".join(traceback.format_exception(error)),
+    )
+    logger.error("Fatal background generation failure for %s: %s: %s", request_id, failure.error_type, failure.message)
+    queue = actor.eval_results_queue if is_eval else actor.results_queue
+    queue.put(failure)
 
 
 FALLBACK_CHAT_TEMPLATE = "{% for message in messages %}{{ message['content'] }}{% endfor %}"
@@ -704,6 +724,8 @@ class LLMRayActor:
         self.request_metadata = {}
         self.active_tasks = {}
         self.request_outputs = {}
+        self._reported_request_failures: set[str] = set()
+        self._request_failure_lock = threading.Lock()
         self.reward_config = reward_config
         self.train_dataset = train_dataset
         self.eval_dataset = eval_dataset
@@ -830,16 +852,12 @@ class LLMRayActor:
     def _init_openai_client(self) -> None:
         base_url = f"http://127.0.0.1:{self.server_port}/v1"
         self.client = openai.AsyncOpenAI(
-            base_url=base_url,
-            api_key="EMPTY",
-            timeout=VLLM_OPENAI_TIMEOUT_S,
-            max_retries=VLLM_OPENAI_MAX_RETRIES,
+            base_url=base_url, api_key="EMPTY", timeout=VLLM_OPENAI_TIMEOUT_S, max_retries=VLLM_OPENAI_MAX_RETRIES
         )
         self.model_name = self.llm_engine.vllm_config.model_config.model
 
         logger.info(
-            "Waiting for vLLM OpenAI API server to be ready at %s "
-            "(timeout=%.1fs, max_retries=%d)",
+            "Waiting for vLLM OpenAI API server to be ready at %s (timeout=%.1fs, max_retries=%d)",
             base_url,
             VLLM_OPENAI_TIMEOUT_S,
             VLLM_OPENAI_MAX_RETRIES,
@@ -942,9 +960,7 @@ class LLMRayActor:
             try:
                 future.result()
             except Exception as e:
-                raise RuntimeError(
-                    f"{source} failed with {type(e).__name__}: {e}\n{traceback.format_exc()}"
-                ) from None
+                raise RuntimeError(f"{source} failed with {type(e).__name__}: {e}\n{traceback.format_exc()}") from None
 
         check_future("vLLM prefetch worker", self._prefetch_future)
         check_future("vLLM completion worker", self._process_future)

--- a/training/open-instruct/tests/test_sandfleet_backend.py
+++ b/training/open-instruct/tests/test_sandfleet_backend.py
@@ -170,6 +170,27 @@ def _transient_error() -> HTTPError:
     return HTTPError("http://controller", 503, "Service Unavailable", {}, body)
 
 
+def test_configuration_rejection_preserves_controller_guidance(monkeypatch):
+    body = io.BytesIO(
+        b'{"error":{"type":"ValueError","message":"Declarative resource requests are disabled; '
+        b'start the controller with --enable-dynamic-resources"}}'
+    )
+
+    def reject(*_args, **_kwargs):
+        raise HTTPError("http://controller", 400, "Bad Request", {}, body)
+
+    monkeypatch.setattr("open_instruct.environments.sandfleet_backend.urlopen", reject)
+
+    with pytest.raises(ValueError, match="--enable-dynamic-resources"):
+        SandfleetBackend()._request(
+            "http://controller",
+            "/v1/lease-requests",
+            token="client-token",
+            method="POST",
+            payload={"resources": {"cpus": 2, "memory_mb": 4096}},
+        )
+
+
 def test_replay_safe_requests_retry_with_backoff(monkeypatch):
     outcomes = iter([_transient_error(), _transient_error(), io.BytesIO(b'{"ok":true}')])
     calls = []


### PR DESCRIPTION
## Summary
- report background rollout-task failures through the inference result queue
- wake data preparation immediately and raise the original request/error context at the trainer
- preserve Sandfleet controller configuration guidance such as `--enable-dynamic-resources`
- simplify touched data-loader predicates and move the Docker import to module scope

## Validation
- macOS: `uv run --frozen ruff check` and `ruff format --check` for all modified files
- macOS: `uv run --frozen pytest -q tests/test_sandfleet_backend.py` (17 passed)
- Hyak Linux: focused Sandfleet/backend, fatal reporter, and batch-consumer tests (19 passed)

The Linux sync omitted `causal-conv1d`, which requires `nvcc` to build and is not imported by these tests.