### PR TITLE
Fix GRPO policy gradient scaling with sequence parallelism

### DIFF
--- a/training/open-instruct/CHANGELOG.md
+++ b/training/open-instruct/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 
 ### Changed
-- Fix GRPO policy gradient scaling with ZeRO-3 sequence parallelism and tiled loss normalization for uneven or empty response shards.
+- Fix GRPO policy gradient scaling with ZeRO-3 sequence parallelism and tiled loss normalization for uneven or empty response shards (https://github.com/hamishivi/tmax/pull/9).
 - Fix Qwen3.5 packing logprob mismatch: call `patch_qwen3_5_packing()` inside `PolicyTrainerRayProcess.from_pretrained()` so the GatedDeltaNet sequence-isolation patch is applied in the Ray worker process, not only in the main process. Without this, packed rows leaked state between sub-sequences, causing `vllm_vs_local_logprob_diff_mean` ~0.21 instead of the expected ~0.02.
 - Build FLA CP context per-batch with `fla.ops.cp.build_cp_context` so Qwen3.5 hybrid linear-attention correctly starts fresh state for packed sub-sequences that don't cross Ulysses SP rank boundaries; threads un-sharded `global_position_ids` through `UlyssesSPSplitter` → `CollatedBatchData` → `compute_logprobs` / `forward_for_logprobs`.
 - Pass `attention_mask=None` in GRPO `forward_for_logprobs` calls — HF constructs the correct 3D intra-document mask from `position_ids` internally (https://github.com/allenai/open-instruct/pull/1617).

--- a/training/open-instruct/CHANGELOG.md
+++ b/training/open-instruct/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 
 ### Changed
+- Fix GRPO policy gradient scaling with ZeRO-3 sequence parallelism and tiled loss normalization for uneven or empty response shards.
 - Fix Qwen3.5 packing logprob mismatch: call `patch_qwen3_5_packing()` inside `PolicyTrainerRayProcess.from_pretrained()` so the GatedDeltaNet sequence-isolation patch is applied in the Ray worker process, not only in the main process. Without this, packed rows leaked state between sub-sequences, causing `vllm_vs_local_logprob_diff_mean` ~0.21 instead of the expected ~0.02.
 - Build FLA CP context per-batch with `fla.ops.cp.build_cp_context` so Qwen3.5 hybrid linear-attention correctly starts fresh state for packed sub-sequences that don't cross Ulysses SP rank boundaries; threads un-sharded `global_position_ids` through `UlyssesSPSplitter` → `CollatedBatchData` → `compute_logprobs` / `forward_for_logprobs`.
 - Pass `attention_mask=None` in GRPO `forward_for_logprobs` calls — HF constructs the correct 3D intra-document mask from `position_ids` internally (https://github.com/allenai/open-instruct/pull/1617).

--- a/training/open-instruct/open_instruct/grpo_fast.py
+++ b/training/open-instruct/open_instruct/grpo_fast.py
@@ -799,17 +799,20 @@ class PolicyTrainerRayProcess(RayProcess):
         if ref_logprobs is not None:
             ref_logprobs = torch.where(response_mask, ref_logprobs, torch.zeros_like(ref_logprobs))
 
-        if loss_denominator_mode == "sequence":
-            loss_weights, _ = grpo_utils._sequence_loss_weights(response_mask, rollout_sample_ids, self._sp_group)
-            current_global_count = loss_weights.sum().float().detach()
-        else:
-            current_global_count = response_mask.sum().float().detach()
-        dist.all_reduce(current_global_count, op=dist.ReduceOp.SUM)
-        # Drain all queued device work through this collective so ranks enter
-        # ZeRO-3 backward with bounded skew.
+        scale = grpo_utils.tiled_grpo_loss_scale(
+            response_mask,
+            loss_denominator,
+            grpo_utils.deepspeed_gradient_reduction_divisor(
+                self.args.world_size, self.args.sequence_parallel_size, self.args.deepspeed_stage
+            ),
+            loss_denominator_mode,
+            rollout_sample_ids,
+            self._sp_group,
+        )
+        # Drain queued device work and keep ranks entering ZeRO-3 backward
+        # with bounded skew, without averaging their distinct local normalizers.
+        dist.barrier()
         torch.cuda.synchronize()
-        dp_world_size = self.args.world_size // self.args.sequence_parallel_size
-        scale = current_global_count * dp_world_size / (self.args.world_size * float(loss_denominator))
         loss, kl_avg, clipfrac, ratio_avg = grpo_utils.tiled_grpo_lm_head_loss(
             lm_head=lm_head,
             hidden_states=hidden_states,
@@ -1379,10 +1382,10 @@ class PolicyTrainerRayProcess(RayProcess):
                     else:
                         loss = masked_mean(per_token_loss_BT, response_mask_BT, None, loss_denominator)
 
-                    # we already took world size into account via the tokens
-                    # but deepspeed will try to average over ranks, so multiply back
-                    # up, adjusting for the sequence parallel size (adjust by dp world size).
-                    loss *= self.args.world_size // self.args.sequence_parallel_size
+                    # The denominator is global; undo DeepSpeed's gradient averaging.
+                    loss *= grpo_utils.deepspeed_gradient_reduction_divisor(
+                        self.args.world_size, self.args.sequence_parallel_size, self.args.deepspeed_stage
+                    )
 
                     # Clear CUDA cache before backward pass to free memory for reduce_scatter operations
                     torch.cuda.empty_cache()

--- a/training/open-instruct/open_instruct/grpo_utils.py
+++ b/training/open-instruct/open_instruct/grpo_utils.py
@@ -968,6 +968,7 @@ class TiledGRPOLMHeadLoss(torch.autograd.Function):
         else:
             loss_weights_2d = mask_2d.to(dtype=torch.float32)
             loss_denom = loss_weights_2d.sum().clamp_min(1.0)
+        loss_denom = loss_denom.clamp_min(1.0)
         loss_weights = loss_weights_2d.reshape(-1)
         metric_denom = mask_2d.to(dtype=torch.float32).sum()
         incoming_grad = (loss_scale.detach().to(dtype=torch.float32) / loss_denom).reshape(())
@@ -1095,6 +1096,36 @@ class TiledGRPOLMHeadLoss(torch.autograd.Function):
         if isinstance(grad, torch.Tensor):
             x_grad = x_grad * grad.to(dtype=x_grad.dtype)
         return (None, x_grad, *([None] * 25))
+
+
+def deepspeed_gradient_reduction_divisor(world_size: int, sequence_parallel_size: int, zero_stage: int) -> int:
+    """Divisor used by the trainer's DeepSpeed gradient reduction configuration.
+
+    ZeRO-3 defaults to reduce_scatter=True, whose coalesced reduction averages
+    over the full sequence-data-parallel group. Stages 0/1/2 compensate for SP
+    and divide by the data-parallel size instead.
+    """
+    return world_size if zero_stage == 3 else world_size // sequence_parallel_size
+
+
+def tiled_grpo_loss_scale(
+    response_mask: torch.Tensor,
+    loss_denominator: float,
+    gradient_reduction_divisor: int,
+    loss_denominator_mode: str = "token",
+    rollout_sample_ids: torch.Tensor | None = None,
+    sequence_process_group: dist.ProcessGroup | None = None,
+) -> torch.Tensor:
+    """Replace the tiled kernel's local normalization with the global denominator."""
+    if loss_denominator_mode == "sequence":
+        _, normalizer = _sequence_loss_weights(response_mask, rollout_sample_ids, sequence_process_group)
+    else:
+        normalizer = response_mask.sum().float()
+    # Match the kernel's clamping, including shards with no response tokens.
+    normalizer = normalizer.clamp_min(1.0).detach()
+    if loss_denominator <= 0:
+        return torch.zeros_like(normalizer)
+    return normalizer * gradient_reduction_divisor / loss_denominator
 
 
 def tiled_grpo_lm_head_loss(

--- a/training/open-instruct/open_instruct/test_grpo_sp_loss_scaling.py
+++ b/training/open-instruct/open_instruct/test_grpo_sp_loss_scaling.py
@@ -1,0 +1,125 @@
+"""CPU gradient parity with SP shards and DeepSpeed's reduction arithmetic.
+
+The sequence-count collectives and final gradient reduction are simulated;
+forward/backward use the real dense and tiled GRPO losses.
+"""
+
+import copy
+from unittest.mock import patch
+
+import pytest
+import torch
+
+from open_instruct import grpo_utils, model_utils
+
+
+@pytest.mark.parametrize("zero_stage", [0, 1, 2, 3])
+@pytest.mark.parametrize("sp_size", [1, 2, 4])
+@pytest.mark.parametrize("mode", ["token", "sequence"])
+@pytest.mark.parametrize("uneven", [False, True])
+def test_sharded_gradients_match_unsharded(zero_stage, sp_size, mode, uneven):
+    torch.manual_seed(12)
+    world_size = 2 * sp_size
+    # Independent reference for DeepSpeed's configured reduction behavior.
+    reduction_divisor = world_size if zero_stage == 3 else 2
+    multiplier = grpo_utils.deepspeed_gradient_reduction_divisor(world_size, sp_size, zero_stage)
+    backbone = torch.nn.Linear(3, 4)
+    head = torch.nn.Linear(4, 7)
+    inputs = torch.randn(2, 2, 8, 3)  # two accumulation steps, two DP samples
+    labels = torch.randint(0, 7, (2, 2, 8))
+    advantages = torch.randn(2, 2, 8)
+    masks = torch.ones(2, 2, 8, dtype=torch.bool)
+    if uneven:
+        masks[0] = torch.tensor([[1, 1, 0, 0, 0, 0, 0, 0], [1, 0, 1, 1, 1, 1, 0, 1]])
+        masks[1, 0] = False
+        masks[1, 1, 4:] = False
+    ids = torch.tensor([0, 0, 0, 0, 1, 1, 1, 1]).expand(2, 2, -1)
+    old_logprobs = model_utils.log_softmax_and_gather(head(backbone(inputs)), labels).detach()
+    weights = masks.float()
+    counts = {}
+    if mode == "sequence":
+        weights = torch.zeros_like(weights)
+        denominator = 0.0
+        for step in range(2):
+            for dp in range(2):
+                counts[step, dp], _ = grpo_utils._sequence_id_counts(masks[step, dp : dp + 1], ids[step, dp : dp + 1])
+                weights[step, dp], seq_count = grpo_utils._sequence_loss_weights(
+                    masks[step, dp : dp + 1], ids[step, dp : dp + 1]
+                )
+                denominator += seq_count.item()
+    else:
+        denominator = masks.sum().item()
+    config = grpo_utils.GRPOExperimentConfig.__new__(grpo_utils.GRPOExperimentConfig)
+    config.loss_fn = grpo_utils.GRPOLossType.dapo
+    config.clip_lower = 0.2
+    config.clip_higher = 0.2
+    config.load_ref_policy = False
+    config.beta = 0.0
+
+    def dense_token_loss(logprobs, old, adv):
+        return grpo_utils.compute_grpo_loss(
+            new_logprobs=logprobs, ratio=torch.exp(logprobs - old), advantages=adv, ref_logprobs=None, config=config
+        )[2]
+
+    logprobs = model_utils.log_softmax_and_gather(head(backbone(inputs)), labels)
+    expected = (dense_token_loss(logprobs, old_logprobs, advantages) * weights).sum() / denominator
+    expected.backward()
+    expected_grads = [p.grad.clone() for model in (backbone, head) for p in model.parameters()]
+
+    for tiled in (False, True):
+        summed_grads = [torch.zeros_like(g) for g in expected_grads]
+        summed_loss = torch.zeros(())
+        for dp in range(2):
+            for sp in range(sp_size):
+                local_backbone, local_head = copy.deepcopy(backbone), copy.deepcopy(head)
+                local_backbone.zero_grad()
+                local_head.zero_grad()
+                chunk = slice(sp * (8 // sp_size), (sp + 1) * (8 // sp_size))
+                for step in range(2):
+                    mask = masks[step, dp : dp + 1, chunk]
+                    local_ids = ids[step, dp : dp + 1, chunk]
+                    local_labels = labels[step, dp : dp + 1, chunk]
+                    hidden = local_backbone(inputs[step, dp : dp + 1, chunk])
+                    old = old_logprobs[step, dp : dp + 1, chunk]
+                    adv = advantages[step, dp : dp + 1, chunk]
+                    if tiled:
+                        # Each SP rank sees the full sequence counts for its DP sample.
+                        with patch.object(
+                            grpo_utils,
+                            "_sequence_id_counts",
+                            return_value=(counts.get((step, dp), torch.zeros(0)), mask),
+                        ):
+                            scale = grpo_utils.tiled_grpo_loss_scale(mask, denominator, multiplier, mode, local_ids)
+                            loss = grpo_utils.tiled_grpo_lm_head_loss(
+                                lm_head=local_head,
+                                hidden_states=hidden,
+                                selected_token_ids=local_labels,
+                                response_mask=mask,
+                                advantages=adv,
+                                old_logprobs=old,
+                                ref_logprobs=None,
+                                temperature=1.0,
+                                beta=0.0,
+                                clip_lower=0.2,
+                                clip_higher=0.2,
+                                shards=2,
+                                loss_scale=scale,
+                                loss_denominator=mode,
+                                rollout_sample_ids=local_ids,
+                            )[0]
+                    else:
+                        local_logprobs = model_utils.log_softmax_and_gather(local_head(hidden), local_labels)
+                        loss = (
+                            (dense_token_loss(local_logprobs, old, adv) * weights[step, dp : dp + 1, chunk]).sum()
+                            / denominator
+                            * multiplier
+                        )
+                    loss.backward()
+                    summed_loss += loss.detach()
+                for total, param in zip(
+                    summed_grads, list(local_backbone.parameters()) + list(local_head.parameters()), strict=True
+                ):
+                    total += param.grad
+        torch.testing.assert_close(summed_loss / reduction_divisor, expected.detach())
+        for actual, target in zip(summed_grads, expected_grads, strict=True):
+            torch.testing.assert_close(actual / reduction_divisor, target, atol=1e-6, rtol=1e-5)


### PR DESCRIPTION
With ZeRO-3 and sequence_parallel_size=4, GRPO policy gradients were reduced by an extra factor of four: the trainer multiplied by the DP size, but DeepSpeed’s default ZeRO-3 coalesced reduce-scatter averages over the full SP×DP group.

Use the full world-size multiplier for ZeRO-3 and preserve the SP compensation used by stages 0–2. Apply the correction to both ordinary and tiled policy loss. The tiled path now cancels its own local token/sequence denominator before applying the global accumulation denominator, so uneven shards are weighted correctly. Clamp empty sequence denominators to keep zero-loss shards finite.

Validation: 110 CPU tests passed, including 48 new gradient-parity cases covering SP=1/2/4, ZeRO=0/1/2/3, token/sequence normalization, balanced/uneven/empty shards, and accumulation. Tests use real dense/tiled backward passes with simulated collectives and gradient reduction. Restoring the old multiplier fails the SP=4 regression with exactly 0.25× the expected result. Ruff format/check and git diff --check pass. No distributed GPU run was performed; reduction behavior was traced against locally installed DeepSpeed 0.18.4.

The optional value-model path uses a separate local-denominator scheme and is outside this policy-loss fix.
